### PR TITLE
Large update of CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,8 @@
-cmake_minimum_required (VERSION 2.8.12)
-project (NAD_program)
-enable_language (Fortran)
+cmake_minimum_required (VERSION 3.5)
+project(ZagHop LANGUAGES Fortran)
 
-###################################################################################################
-# Options.                                                                                        #
-  if(NOT DEFINED CMAKE_BUILD_TYPE OR "${CMAKE_BUILD_TYPE}" STREQUAL "")
-    set(CMAKE_BUILD_TYPE "Release" CACHE STRING
-        "Choose the type of build, options are: Release, Debug and DebugAll ..."
-        FORCE)
-  endif()
-  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Release Debug DebugAll)
+################################################################################
+# Options.                                                                     #
 
   set(LINALG MKL CACHE STRING "Linear algebra library.")
   set_property(CACHE LINALG PROPERTY STRINGS MKL OpenBLAS)
@@ -26,87 +19,68 @@ enable_language (Fortran)
   include_directories(${CMAKE_Fortran_MODULE_DIRECTORY})
   link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 
-###################################################################################################
-# Compiler specific options:                                                                      #
+
+################################################################################
+# Targets:                                                                     #
+  file(GLOB SOURCES "src/core/*f90" "src/util/*f90")
+  if(QUANTICS)
+      set(SOURCES ${SOURCES} "interface/quantics_inter.f90")
+  endif()
+
+  add_executable(zaghop ${SOURCES})
+
+################################################################################
+# Compiler specific options:                                                   #
   if(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
     set(dialect "-fpp -assume realloc_lhs")
-    set(CMAKE_Fortran_FLAGS_RELEASE  "-O3")
-    set(CMAKE_Fortran_FLAGS_DEBUG    "-O2 -traceback -g")
-    set(CMAKE_Fortran_FLAGS_DEBUGALL "-O0 -traceback -g -check all -debug all")
   elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
     set(dialect "-cpp -ffree-line-length-0")
-    set(CMAKE_Fortran_FLAGS_RELEASE  "-O3")
-    set(CMAKE_Fortran_FLAGS_DEBUG "-O2 -fbacktrace -g")
-    set(CMAKE_Fortran_FLAGS_DEBUGALL "-O0 -fbacktrace -Wall -pedantic -fcheck=all -fbounds-check -g")
   endif()
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${dialect}")
 
-###################################################################################################
-# Libraries.                                                                                      #
+################################################################################
+# Libraries.                                                                   #
+
   add_definitions(-DLINALG=1)
-  # CMake FindBLAS/FindLAPACK modules don't work for ilp64 version of MKL or for MKL F95 interface.
-  # Set everything manually.
-    message(STATUS "LINALG = ${LINALG}")
   if(LINALG STREQUAL "MKL")
-    set(MKLROOT "" CACHE PATH "MKL root directory.")
-    set(F95ROOT "" CACHE PATH "MKL F95 interface root directory.")
-    if(MKLROOT STREQUAL "")
-      set(MKLROOT $ENV{MKLROOT})
-      if(NOT MKLROOT)
-        message(FATAL_ERROR
-                "When using MKL, set MKLROOT environment variable "
-                "or call cmake with -DMKLROOT=/path/to/mklroot_dir")
-      endif()
-    endif()
-    if(F95ROOT STREQUAL "")
-      set(F95ROOT $ENV{F95ROOT})
-      if(NOT F95ROOT)
-        message(FATAL_ERROR
-                "When using MKL, set F95ROOT environment variable "
-                "or call cmake with -DF95ROOT=/path/to/f95root_dir")
-      endif()
-    endif()
-    message(STATUS "MKLROOT = ${MKLROOT}")
-    message(STATUS "F95ROOT = ${F95ROOT}")
-    # F95 Interface:
-    include_directories(${F95ROOT}/include/intel64/lp64)
-    set(F95_LIBS ${F95ROOT}/lib/intel64/libmkl_blas95_lp64.a)
-    set(F95_LIBS ${F95_LIBS} ${F95ROOT}/lib/intel64/libmkl_lapack95_lp64.a)
-    set(LINKLIBS ${LINKLIBS} ${F95_LIBS})
-    # MKL libraries.
-    include_directories(${MKLROOT}/include/)
-    set(MKL_LIBS "-Wl,--no-as-needed -Wl,--start-group")
-    if(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
-        set(MKL_LIBS ${MKL_LIBS} "-lmkl_intel_lp64 -lmkl_intel_thread")
-    elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
-        set(MKL_LIBS ${MKL_LIBS} "-lmkl_gf_lp64 -lmkl_gnu_thread")
-        set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -m64")
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DMKL_LP64 -m64")
-    elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "PGI")
-        set(MKL_LIBS ${MKL_LIBS} "-lmkl_intel_lp64 -lmkl_pgi_thread")
-        set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -pgf90libs")
-    endif()
-    set(MKL_LIBS ${MKL_LIBS} "-lmkl_core -Wl,--end-group -lpthread -lm -ldl")
-    if(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
-        set(MKL_LIBS ${MKL_LIBS} "-liomp5")
-    elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
-        set(MKL_LIBS ${MKL_LIBS} "-lgomp")
-    elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "PGI")
-        set(MKL_LIBS ${MKL_LIBS} "-pgf90libs")
-    endif()
-    set(LINKLIBS ${LINKLIBS} ${MKL_LIBS})
+    set(MKL_INTERFACE "lp64")
+    set(ENABLE_BLAS95 ON CACHE BOOL "Enables BLAS Fortran95 API")
+    set(ENABLE_LAPACK95 ON CACHE BOOL "Enables LAPACK Fortran95 API")
+    find_package(MKL CONFIG REQUIRED)
+    target_compile_options(zaghop PRIVATE
+        $<TARGET_PROPERTY:MKL::MKL,INTERFACE_COMPILE_OPTIONS>)
+    target_include_directories(zaghop PRIVATE
+        $<TARGET_PROPERTY:MKL::MKL,INTERFACE_INCLUDE_DIRECTORIES>)
+    target_link_libraries(zaghop PRIVATE $<LINK_ONLY:MKL::MKL>)
     add_definitions(-DMKL=1)
     add_definitions(-DLINALG_F95=1)
-  elseif(LINALG STREQUAL "OpenBLAS")
-    find_package(OpenBLAS)
-    include_directories(${OpenBLAS_INCLUDE_DIRS})
-    message(STATUS BLAS found: ${OpenBLAS_LIBRARIES})
-    set(LINKLIBS ${LINKLIBS} ${OpenBLAS_LIBRARIES})
-    add_definitions(-DOPENBLAS=1)
+    # MKLConfig.cmake can only set up BLAS95 and LAPACK95 with Intel compilers
+    # so they are specified manually here for gfortran.
+    if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+      set(F95ROOT "" CACHE PATH "MKL F95 interface root directory.")
+      if(F95ROOT STREQUAL "")
+        set(F95ROOT $ENV{F95ROOT})
+        if(NOT F95ROOT)
+          message(FATAL_ERROR
+                  "When using MKL, set F95ROOT environment variable "
+                  "or call cmake with -DF95ROOT=/path/to/f95root_dir")
+        endif()
+      endif()
+      message(STATUS "F95ROOT = ${F95ROOT}")
+      target_include_directories(zaghop PRIVATE
+          ${F95ROOT}/include/intel64/lp64)
+      target_link_libraries(zaghop PRIVATE
+          ${F95ROOT}/lib/intel64/libmkl_blas95_lp64.a)
+      target_link_libraries(zaghop PRIVATE
+          ${F95ROOT}/lib/intel64/libmkl_lapack95_lp64.a)
+    endif()
   elseif(LINALG STREQUAL "Quantics")
+    if(NOT QUANTICS)
+        message(FATAL_ERROR
+                "QUANTICS=ON needs to be set in order to use LINALG=Quantics.")
+    endif()
     message(STATUS Quantics BLAS: $ENV{QUANTICS_DIR})
-    add_definitions(-DQUANTICS=1)
-
+    add_definitions(-DLINALG_QUANTICS=1)
   endif()
 
   if(QUANTICS)
@@ -116,60 +90,39 @@ enable_language (Fortran)
     set(QUANTICS_COMPILER $ENV{QUANTICS_COMPILER})
     if(NOT (QUANTICS_DIR AND QUANTICS_PLATFORM AND QUANTICS_COMPILER))
       message(FATAL_ERROR
-              "To compile with Quantics interface, set QUANTICS_DIR, QUANTICS_PLATFORM "
-              "and QUANTICS_COMPILER environment variables.")
+              "To compile with Quantics interface, set QUANTICS_DIR, "
+              "QUANTICS_PLATFORM and QUANTICS_COMPILER environment variables.")
     endif()
     if(QUANTICS_COMPILER STREQUAL "default")
       set(QUANTICS_COMPILER "gfortran")
     endif()
-    set(QUANTICS_OBJ ${QUANTICS_DIR}/object/${QUANTICS_PLATFORM}/${QUANTICS_COMPILER})
-    set(QUANTICS_LIB ${QUANTICS_DIR}/bin/dyn_libs)
-    include_directories(${QUANTICS_OBJ}/include)
-    set(QUANTICS_INTER "interface/quantics_inter.f90")
-    set(LINKLIBS ${LINKLIBS} ${QUANTICS_OBJ}/versions.o)
-    set(LINKLIBS ${LINKLIBS} ${QUANTICS_OBJ}/mctdh.a)
-    set(LINKLIBS ${LINKLIBS} ${QUANTICS_OBJ}/propwf.a)
-    set(LINKLIBS ${LINKLIBS} ${QUANTICS_OBJ}/geninwf.a)
-    set(LINKLIBS ${LINKLIBS} ${QUANTICS_OBJ}/genoper.a)
-    set(LINKLIBS ${LINKLIBS} ${QUANTICS_OBJ}/gendvr.a)
-    set(LINKLIBS ${LINKLIBS} ${QUANTICS_OBJ}/quanticslib.a)
-    set(LINKLIBS ${LINKLIBS} ${QUANTICS_OBJ}/opfuncs.a)
-    set(LINKLIBS ${LINKLIBS} ${QUANTICS_OBJ}/libode.a)
-    set(LINKLIBS ${LINKLIBS} ${QUANTICS_OBJ}/quanticsmod.a)
-    set(LINKLIBS ${LINKLIBS} ${QUANTICS_OBJ}/includes.a)
-    set(LINKLIBS ${LINKLIBS} ${QUANTICS_OBJ}/globinc.a)
-    set(LINKLIBS ${LINKLIBS} ${QUANTICS_OBJ}/libnum.a)
-    set(LINKLIBS ${LINKLIBS} ${QUANTICS_OBJ}/libsys.a)
-    set(LINKLIBS ${LINKLIBS} ${QUANTICS_OBJ}/libarpack.a)
-    set(LINKLIBS ${LINKLIBS} ${QUANTICS_OBJ}/liblapack.a)
-    set(LINKLIBS ${LINKLIBS} ${QUANTICS_OBJ}/libblas.a)
-    set(LINKLIBS ${LINKLIBS} ${QUANTICS_OBJ}/libomp.a)
-    set(LINKLIBS ${LINKLIBS} "-J ${QUANTICS_OBJ}/include -lsqlite3 -L ${QUANTICS_DIR}/bin/dyn_libs -lsrf -lusrf -lsqlite3")
-  endif()
-
-  if(OMP)
-    find_package(OpenMP REQUIRED)
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${OpenMP_Fortran_FLAGS}")
-    message(STATUS "OpenMP libraries:  ${OpenMP_Fortran_LIB_NAMES}")
+    set(QUANTICS_OBJ 
+       ${QUANTICS_DIR}/object/${QUANTICS_PLATFORM}/${QUANTICS_COMPILER})
+    target_include_directories(zaghop PRIVATE ${QUANTICS_OBJ}/include)
+    target_link_directories(zaghop PRIVATE ${QUANTICS_DIR}/bin/dyn_libs)
+    target_link_directories(zaghop PRIVATE ${QUANTICS_OBJ})
+    target_link_libraries(zaghop PRIVATE
+    ${QUANTICS_OBJ}/versions.o
+    ${QUANTICS_OBJ}/mctdh.a
+    ${QUANTICS_OBJ}/propwf.a
+    ${QUANTICS_OBJ}/geninwf.a
+    ${QUANTICS_OBJ}/genoper.a
+    ${QUANTICS_OBJ}/gendvr.a
+    ${QUANTICS_OBJ}/quanticslib.a
+    ${QUANTICS_OBJ}/opfuncs.a
+    ${QUANTICS_OBJ}/libode.a
+    ${QUANTICS_OBJ}/quanticsmod.a
+    ${QUANTICS_OBJ}/includes.a
+    ${QUANTICS_OBJ}/globinc.a
+    ${QUANTICS_OBJ}/libnum.a
+    ${QUANTICS_OBJ}/libsys.a
+    ${QUANTICS_OBJ}/libarpack.a
+    ${QUANTICS_OBJ}/liblapack.a
+    ${QUANTICS_OBJ}/libblas.a
+    ${QUANTICS_OBJ}/libomp.a)
+    target_link_libraries(zaghop PRIVATE srf usrf sqlite3)
   endif()
 
   if(STATIC)
-    set(LINKLIBS ${LINKLIBS} "-static")
+    target_link_libraries(zaghop PRIVATE "-static")
   endif()
-
-################################################################################
-# Build                                                                        #
-  file(GLOB SOURCES "src/core/*f90" "src/util/*f90")
-  if(QUANTICS)
-      set(SOURCES ${SOURCES} ${QUANTICS_INTER})
-  endif()
-
-
-  add_executable(nad.exe ${SOURCES})
-  target_link_libraries(nad.exe ${LINKLIBS})
-
-  add_custom_command(
-        TARGET nad.exe POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy
-                ${CMAKE_SOURCE_DIR}/interface/*py
-                ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/)

--- a/src/core/interface.f90
+++ b/src/core/interface.f90
@@ -138,10 +138,10 @@ contains
             write(stderr, *) 'Error in run_qm. Code not compiled with quantics interface.'
             stop
 #endif
-         case default
-             write(stderr, *) 'Error in run_qm. Unrecognized QM interface.'
-             stop
-         end select
+        case default
+            write(stderr, *) 'Error in run_qm. Unrecognized QM interface.'
+            stop
+        end select
     end subroutine run_qm
 
 

--- a/src/util/file.f90
+++ b/src/util/file.f90
@@ -77,7 +77,7 @@ contains
         logical, intent(in), optional :: abort_on_eof !< Abort on eof or return iostat.
         logical, intent(in), optional :: abort_on_error !< Abort on eof or return iostat.
 
-        self%file=file_name
+        self%file=trim(file_name)
         call need_file(self%file)
         open(newunit=self%unit, file=self%file, action='read', status='old')
     
@@ -234,6 +234,7 @@ contains
         logical :: tcase_sensitive
         logical :: check
         integer :: c
+        character(len=:), allocatable :: errmsg
         
         tcase_sensitive = .true.
         if (present(case_sensitive)) tcase_sensitive = case_sensitive
@@ -247,9 +248,8 @@ contains
                     found = .false.
                     return
                 else
-                    write(stderr, *) 'Error in reader_go_to_keyword subroutine.'
-                    write(stderr, *) 'Keyword "', keyword, '" not found in file "', self%file, '".'
-                    call abort()
+                    errmsg = 'Keyword "'//keyword//'" not found in file "'//self%file//'".'
+                    call errstop('reader_go_to_keyword', errmsg, 1)
                 end if
             end if
             if (keyword == '') then

--- a/src/util/global_defs.f90
+++ b/src/util/global_defs.f90
@@ -38,15 +38,6 @@ module global_defs
     real(dp), parameter :: pio2 = pi / num2
 
 
-! intel v15.0 doesn't print backtrace with call abort()
-#if __INTEL_COMPILER
-    interface 
-        subroutine abort() bind(C, name="abort")
-        end subroutine
-    end interface
-#endif
-
-
  !  !----------------------------------------------------------------------------------------------
  !  ! TYPE: IVec
  !  !> @brief Array of integer vectors of varying dimensions.
@@ -112,6 +103,7 @@ contains
         write(stderr, '(1x,a)') 'Error in '//errsub//'.'
         if (present(errmsg)) write(stderr, '(3x, a, a)')  'Error: ', errmsg
         if (present(errnum)) write(stderr, '(3x, a, i0)')  'Status: ', errnum
+        flush(stderr)
         call abort()
     end subroutine errstop
 

--- a/src/util/linalg_wrapper.f90
+++ b/src/util/linalg_wrapper.f90
@@ -8,9 +8,9 @@ module linalg_wrapper_mod
     public
 
 #ifndef LINALG_F95
-interface gemm
-   module procedure gemm, cgemm
-end interface gemm
+    interface gemm
+        module procedure gemm_d, gemm_z
+    end interface gemm
 #endif
 
 contains
@@ -49,8 +49,7 @@ contains
     end subroutine gemv
 
 
-    subroutine gemm(a, b, c, transa, transb, alpha, beta)
-        !> @todo add complex version
+    subroutine gemm_d(a, b, c, transa, transb, alpha, beta)
         real(dp) :: a(:, :)
         real(dp) :: b(:, :)
         real(dp) :: c(:, :)
@@ -85,10 +84,10 @@ contains
             k = size(a, 2)
         end if
         call dgemm(wrk_transa, wrk_transb, m, n, k, wrk_alpha, a, lda, b, ldb, wrk_beta, c, ldc)
-    end subroutine gemm
+    end subroutine gemm_d
 
 
-    subroutine cgemm(a, b, c, transa, transb, alpha, beta)
+    subroutine gemm_z(a, b, c, transa, transb, alpha, beta)
         complex(dp) :: a(:, :)
         complex(dp) :: b(:, :)
         complex(dp) :: c(:, :)
@@ -115,7 +114,7 @@ contains
         wrk_beta = cmplx(num0, num0, dp)
         if (present(beta)) wrk_beta = beta
         m = lda
-        if (transa /= 'N') then
+        if (wrk_transa /= 'N') then
             m = size(a, 2)
             k = lda
         else
@@ -123,7 +122,7 @@ contains
             k = size(a, 2)
         end if
         call zgemm(wrk_transa, wrk_transb, m, n, k, wrk_alpha, a, lda, b, ldb, wrk_beta, c, ldc)
-    end subroutine cgemm
+    end subroutine gemm_z
 
 
     subroutine ger(a, x, y, alpha)


### PR DESCRIPTION
  Fix compilation with gfortran and LINALG=MKL and switch to using find_package
  for MKL (uses the "MKLConfig.cmake" provided with newer versions of MKL).
  This still doesn't properly enable F95 interfaces for non-Intel compilers
  so that case is still handled manually.

  Also removed unused options from CMakeLists.txt and cleaned-up the file.

  Tested for ifort and gfortran with both LINALG=Quantics and LINALG=MKL and
  fixed several issues.